### PR TITLE
실시간 돌발 정보를 오래된 것부터 최대 10개 응답

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,5 @@
+DEBUG=True
+
+# you can get your own key from:
+# https://data.seoul.go.kr/dataList/datasetView.do?infId=OA-13315&srvType=A&serviceKind=1&currentPageNo=1
+SEOUL_API_KEY=

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,10 @@
+# IDE
+.idea
+*.iml
+
+# secrets
+.env*
+!.env.sample
+
+# python
+__pycache__

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# I DOLBAL U rest api
+
+서울시 실시간 돌발 정보 조회
+
+## Prerequisites
+
+you should get your own dotenv file at `backend/.env` see `.env.sample`.
+
+## Run local server
+
+install dependencies:
+
+```shell script
+(your_python3_env) $ pip install -r requirements.txt
+```
+
+run server:
+
+```shell script
+(your_python3_env) $ uvicorn main:app --reload
+```
+
+## API Documentation
+
+after running server, visit following URLs:
+
+- localhost:<port=8000>/docs
+- localhost:<port=8000>/redoc
+
+## More info
+
+related links:
+- [서울 열린데이터 광장](https://data.seoul.go.kr/dataList/datasetView.do?infId=OA-13315&srvType=A&serviceKind=1&currentPageNo=1)
+- [Frontend README](https://github.com/constmoon/dolbal/blob/master/README.md)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,29 @@
+from typing import List
+import requests
+
+from fastapi import FastAPI
+from starlette.responses import JSONResponse, Response
+
+from parser import parse
+from models import Accident
+from settings import SEOUL_API_URL, SEOUL_API_KEY
+
+app = FastAPI(
+    title='I DOLBAL U',
+    description='서울시 돌발정보 열람 서버',
+    version='v1',
+)
+
+
+@app.get('/accidents', response_model=List[Accident])
+async def get_accidents(response: Response):
+    response = requests.get(
+        f'{str(SEOUL_API_URL)}/{str(SEOUL_API_KEY)}/xml/AccInfo/1/10'
+    )
+
+    total_count, accidents = parse(response.text)
+
+    headers = {'X-Total-Count': total_count}
+    content = {'data': accidents}
+
+    return JSONResponse(content=content, headers=headers)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class Accident(BaseModel):
+    starts_at_date: str
+    starts_at_time: str
+    ends_at_date: str
+    ends_at_time: str
+    x_coordinate: str
+    y_coordinate: str
+    description: str

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,0 +1,20 @@
+from xml.etree import ElementTree
+
+
+def parse(s: str):
+    root = ElementTree.fromstring(s)
+
+    total_count = root.find('list_total_count').text
+    accidents = [
+        {
+            'starts_at_date': row.find('occr_date').text,
+            'starts_at_time': row.find('occr_time').text,
+            'ends_at_date': row.find('exp_clr_date').text,
+            'ends_at_time': row.find('exp_clr_time').text,
+            'x_coordinate': row.find('grs80tm_x').text,
+            'y_coordinate': row.find('grs80tm_y').text,
+            'description': row.find('acc_info').text,
+        } for row in root.findall('row')
+    ]
+
+    return total_count, accidents

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,15 @@
+certifi==2019.9.11
+chardet==3.0.4
+Click==7.0
+fastapi==0.42.0
+h11==0.8.1
+httptools==0.0.13
+idna==2.8
+lxml==4.4.1
+pydantic==0.32.2
+requests==2.22.0
+starlette==0.12.9
+urllib3==1.25.6
+uvicorn==0.10.4
+uvloop==0.14.0rc2
+websockets==8.1

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,8 @@
+from starlette.config import Config
+from starlette.datastructures import Secret, URL
+
+config = Config(".env")
+
+DEBUG = config("DEBUG", cast=bool, default=False)
+SEOUL_API_KEY = config("SEOUL_API_KEY", cast=Secret)
+SEOUL_API_URL = config("SEOUL_API_URL", cast=URL)


### PR DESCRIPTION
## 개요

서울시 실시간 돌발 정보를 열람하는 프락시 서버를 FastAPI를 사용해서 만들었습니다

## 변경사항

- FastAPI 앱 추가
  - /accidents 엔드포인트 추가
  - Accident 모델 추가

## 테스트 방법

README를 참고하여 로컬 서버를 띄우고:
1. /accidents 에 접속해서 응답 데이터를 확인
2. /docs 또는 /redoc 에 접속해서 API 명세를 확인

## 연관이슈

#1  